### PR TITLE
feat(deps): replace celery by celery-rs + fix lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,8 +264,8 @@ where
         #[cfg(feature = "tracing")]
         {
             let span = Span::current();
-            span.record("index", &display(index));
-            span.record("service", &debug(&self.sources[index]));
+            span.record("index", display(index));
+            span.record("service", debug(&self.sources[index]));
         }
 
         // Connect if not already connected

--- a/tourniquet-celery/Cargo.toml
+++ b/tourniquet-celery/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-celery = { version = "0.5", default-features = false }
+celery-rs = { version = "0.6", default-features = false }
 log = "0.4"
 tourniquet = { version = "0.4", path = ".." }
 tracing = { version = "0.1", optional = true }


### PR DESCRIPTION
Edit to use [fork of Celery](https://github.com/GaiaNet-AI/celery-rs) as the original [rusty-celery](https://github.com/rusty-celery/rusty-celery) project became inactive.